### PR TITLE
armageddon update

### DIFF
--- a/game/scripts/npc/abilities/shadow_priest_armageddon.txt
+++ b/game/scripts/npc/abilities/shadow_priest_armageddon.txt
@@ -32,6 +32,7 @@
 		"modifier_armageddon"
 		{
 			"Duration"				"%duration"
+			"Attributes"	"MODIFIER_ATTRIBUTE_MULTIPLE"
 			"ThinkInterval"			"%interval"
 			"OnIntervalThink"
 			{
@@ -68,12 +69,17 @@
 		"05"
 		{
 			"var_type"				"FIELD_FLOAT"
-			"interval"				"0.69 0.63 0.57 0.51 0.45 0.39 0.33 0.27 0.21 0.15"
+			"interval"				"0.8"
 		}
 		"06"
 		{
 			"var_type"				"FIELD_INTEGER"
 			"meteor_fall_area"		"800"
+		}
+		"07"
+		{
+			"var_type"				"FIELD_FLOAT"
+			"delay"					"0.69 0.63 0.57 0.51 0.45 0.39 0.33 0.27 0.21 0.15"
 		}
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -10286,6 +10286,7 @@
 			"modifier_armageddon"
 			{
 				"Duration"				"%duration"
+				"Attributes"	"MODIFIER_ATTRIBUTE_MULTIPLE"
 				"ThinkInterval"			"%interval"
 				"OnIntervalThink"
 				{
@@ -10322,12 +10323,17 @@
 			"05"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"interval"				"0.69 0.63 0.57 0.51 0.45 0.39 0.33 0.27 0.21 0.15"
+				"interval"				"0.8"
 			}
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
 				"meteor_fall_area"		"800"
+			}
+			"07"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"delay"					"0.69 0.63 0.57 0.51 0.45 0.39 0.33 0.27 0.21 0.15"
 			}
 		}
 	}


### PR DESCRIPTION
Modified Armageddon to work more like its MT 1.93 equivalent:
-Time between meteors increased to 0.8 seconds. It now summons 25 meteors over 20 seconds at all levels.
-Meteors no longer land instantly, and instead are delayed by 0.69/0.63/0.57/0.51/0.45/0.39/0.33/0.27/0.21/0.15 seconds.
-Added sunstrike charge effect inbetween landing time.
-Armageddon is now stackable if brought off cooldown early(by Chanter ult etc.).

Confirmed working offline, possibly needs online testing.